### PR TITLE
Fix Container Naming Bug

### DIFF
--- a/.github/workflows/release-jivas.yaml
+++ b/.github/workflows/release-jivas.yaml
@@ -119,7 +119,7 @@ jobs:
           file: ./docker/jivas.Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/jivas:latest
-            ghcr.io/${{ github.repository_owner }}/jivas:${{ needs.check-version.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner == github.repository_owner && github.repository_owner || github.repository_owner | lowercase }}/jivas:latest
+            ghcr.io/${{ github.repository_owner == github.repository_owner && github.repository_owner || github.repository_owner | lowercase }}/jivas:${{ needs.check-version.outputs.new_version }}
           build-args: |
             JIVAS_VERSION=${{ needs.check-version.outputs.new_version }}

--- a/.github/workflows/release-jivas.yaml
+++ b/.github/workflows/release-jivas.yaml
@@ -112,6 +112,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Private Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.v75inc.dev
+          username: ${{ secrets.V75_REGISTRY_USER }}
+          password: ${{ secrets.V75_REGISTRY_PASSWORD }}
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -121,5 +134,9 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner == github.repository_owner && github.repository_owner || github.repository_owner | lowercase }}/jivas:latest
             ghcr.io/${{ github.repository_owner == github.repository_owner && github.repository_owner || github.repository_owner | lowercase }}/jivas:${{ needs.check-version.outputs.new_version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/jivas:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/jivas:${{ needs.check-version.outputs.new_version }}
+            registry.v75inc.dev/jivas-jaclang/jivas:latest
+            registry.v75inc.dev/jivas-jaclang/jivas:${{ needs.check-version.outputs.new_version }}
           build-args: |
             JIVAS_VERSION=${{ needs.check-version.outputs.new_version }}

--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.20"
+__version__ = "2.0.0-alpha.21"


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature
- [x] 🔧 Infrastructure
- [ ] 📝 Docs
- [x] 🔄 Version Bump

## Summary

This PR enhances the release pipeline for the `jivas` package by improving Docker image publishing across multiple registries and bumping the package version to `2.0.0-alpha.21`.

## Key Changes

### 🐳 Docker Workflow Enhancements
- **Added login steps** for:
  - Docker Hub
  - A private Docker registry
- **Updated `tags:`** for Docker image publishing to support:
  - GitHub Container Registry
  - Docker Hub (`docker.io`)
  - Private registry (via `PRIVATE_REGISTRY_URL`)

### 🏷️ Version Update
- `jivas/__init__.py`: Bumped version from `2.0.0-alpha.20` → `2.0.0-alpha.21`

## Why It Matters

- Enables consistent multi-registry image publishing for better flexibility across environments.
- Supports organizations using Docker Hub and private registries alongside GHCR.
- Keeps semantic versioning in sync with release output.

## Notes
Ensure secrets for `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `PRIVATE_REGISTRY_USERNAME`, `PRIVATE_REGISTRY_PASSWORD`, and `PRIVATE_REGISTRY_URL` are configured in repository settings.
