### PR TITLE
Alpha.28

### DIFF
--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.27"
+__version__ = "2.0.0-alpha.28"

--- a/jivas/agent/action/interact.jac
+++ b/jivas/agent/action/interact.jac
@@ -259,9 +259,16 @@ walker interact :interact_graph_walker: {
 
         # add new interaction node to the frame, or assume one which is open and already added
         # interaction nodes may be programmatically added and initialized in webhook type actions before interact is called
+        add_interaction = False;
         self.interaction_node = self.frame_node.get_last_interaction();
 
-        if(self.interaction_node.is_closed()) {
+        if self.interaction_node is None {
+            add_interaction = True;
+        } elif self.interaction_node.is_closed() {
+            add_interaction = True;
+        }
+
+        if(add_interaction) {
             self.interaction_node = self.frame_node.add_interaction(
                 utterance=self.utterance,
                 channel=self.channel

--- a/jivas/agent/action/interact.jac
+++ b/jivas/agent/action/interact.jac
@@ -44,7 +44,6 @@ walker interact :interact_graph_walker: {
     has context_data: dict = {};
     has frame_node: Frame = None;
     has interaction_node: Interaction = None;
-    has last_interaction_node: InteractAction = None;
     has agent_node: Agent = None;
 
     obj __specs__ {
@@ -57,7 +56,6 @@ walker interact :interact_graph_walker: {
             "context_data",
             "frame_node",
             "interaction_node",
-            "last_interaction_node",
             "agent_node"
         ]; # Supported in jac-cloud > 0.0.3
     }
@@ -84,7 +82,10 @@ walker interact :interact_graph_walker: {
 
         # the interact walk, sorts the interact actions by weight to preserve execution order before walk
 
-        if (resume_action_node := self.frame_node.get_resume_action(self.last_interaction_node)) {
+        # since we have a fresh interaction node at this point, we have to up the depth of retraces to get the last one
+        last_interaction_node = self.frame_node.get_last_interaction(retraces=2);
+
+        if (resume_action_node := self.frame_node.get_resume_action(last_interaction_node)) {
             # add any resumption directives from the last interaction node of the frame...
             root_action_node = resume_action_node.get_root_action();
             self.interaction_node.add_intent(root_action_node.label);
@@ -256,14 +257,16 @@ walker interact :interact_graph_walker: {
             );
         }
 
-        # save last interaction, if any
-        self.last_interaction_node = self.frame_node.get_last_interaction();
+        # add new interaction node to the frame, or assume one which is open and already added
+        # interaction nodes may be programmatically added and initialized in webhook type actions before interact is called
+        self.interaction_node = self.frame_node.get_last_interaction();
 
-        # add new interaction node to the frame
-        self.interaction_node = self.frame_node.add_interaction(
-            utterance=self.utterance,
-            channel=self.channel
-        );
+        if(self.interaction_node.is_closed()) {
+            self.interaction_node = self.frame_node.add_interaction(
+                utterance=self.utterance,
+                channel=self.channel
+            );
+        }
 
         if (not self.interaction_node) {
             return False;
@@ -593,6 +596,9 @@ walker interact :interact_graph_walker: {
             self.frame_node.prune_interactions(
                 frame_size=self.agent_node.frame_size
             );
+
+            # close the interaction
+            self.interaction_node.close();
 
         } else {
             self.message = SilentInteractionMessage();

--- a/jivas/agent/memory/frame.jac
+++ b/jivas/agent/memory/frame.jac
@@ -39,12 +39,10 @@ node Frame :GraphNode: {
         }
     }
 
-    can get_last_interaction() -> Interaction {
-        # retrieves the last interaction in this frame
-        if(result := [-:Tail:->](`?Interaction)) {
-            return Utils.node_obj(result);
-        }
-        return None;
+    can get_last_interaction(retraces:int=1) -> Interaction {
+        # retrieves the last interaction in this frame by default;
+        # can attempt to retrace by a number specified in the retraces param to retrieve older interactions
+        return (self spawn _get_interaction_by_retraces(retraces = retraces)).interaction_node;
     }
 
     can is_first_interaction -> bool {
@@ -108,6 +106,9 @@ node Frame :GraphNode: {
                 message=TextInteractionMessage(content=message).export()
             ).export()
         );
+
+        # close the unprompted interaction
+        interaction_node.close();
 
         return self.insert_interaction(interaction_node, last_interaction_node);
     }
@@ -301,6 +302,34 @@ walker _get_interactions {
     can on_interaction with Interaction entry {
         self.interactions.append(here);
         visit [-:Advance:->](`?Interaction);
+    }
+}
+
+walker _get_interaction_by_retraces {
+    # retraces from frame by a factor of 'retraces' to retrieve any interaction found
+    has retraces:int = 1;
+    has walks:int = 0;
+    has interaction_node:Interaction = None;
+
+    obj __specs__ {
+        # make this a private walker
+        static has private: bool = True;
+    }
+
+    can on_frame with Frame entry {
+        visit [-:Tail:->](`?Interaction);
+    }
+
+    can on_interaction with Interaction entry {
+
+        self.walks += 1;
+
+        if(self.retraces == self.walks) {
+            self.interaction_node = here;
+            disengage;
+        }
+
+        visit [-:Retrace:->](`?Interaction);
     }
 }
 

--- a/jivas/agent/memory/interaction.jac
+++ b/jivas/agent/memory/interaction.jac
@@ -21,6 +21,7 @@ node Interaction :GraphNode: {
     has events: list = [];
     has response: dict = {};
     has data:dict = {};
+    has closed:bool = False; # flag to determine whether interaction is complete / closed or not
 
     can attach_interaction(interaction_node:Interaction) {
         # attaches a new interaction node to this one
@@ -158,6 +159,14 @@ node Interaction :GraphNode: {
 
     can get_functions(action_label:str) -> list {
         return self.functions.get(action_label, []);
+    }
+
+    can is_closed() -> bool {
+        return self.closed;
+    }
+
+    can close() {
+        self.closed = True;
     }
 
 }


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [ ] 🐛 Bug Fix
- [x] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
- Adds a feature to allow `get_last_interaction` to accept a `retraces` parameter for controlling the age of the last interaction.
- Refactors the interact walker to reuse a preconfigured interaction node, useful in webhook scenarios.

---

## **Description**
### **Feature Request**:
- **Description**: Enhanced the `get_last_interaction` to include a `retraces` parameter.
- **Motivation**: To provide flexibility in determining the relevant last interaction based on a specified age.
- **Details**: The parameter allows users to specify how far back in history the last interaction should be considered.

### **Refactor Request**:
- **Code Area**: Interact walker.
- **Problem**: Previously, the interact walker did not efficiently utilize preconfigured interaction nodes, leading to redundancy.
- **Improvements**: Modified to check for and use an initialized interaction node, enhancing performance and modularity in webhook-like scenarios.

---

## **Changes Made**
### High-Level Summary:
1. Added `retraces` parameter to `get_last_interaction` in `interact.jac`.
2. Updated memory files to support the new parameter.
3. Refactored the interact walker for node reusability when set programmatically.

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Provide a clear set of steps for testing the changes introduced in this PR:
1. Configure an interaction node programmatically.
2. Call the interact walker and verify the reuse of the preconfigured node.
3. Test `get_last_interaction` with various `retraces` values to ensure proper functionality.

---

## **Additional Context**
If necessary, provide additional context, screenshots, or relevant references for the changes in this PR.

---

## **Questions or Concerns**
Are there any open questions or areas of concern related to this PR? If so, mention them here.