### PR TITLE
Docker Entrypoint Refactor

### DIFF
--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.28"
+__version__ = "2.0.0-alpha.29"


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request updates the `docker/entrypoint.sh` script to replace the use of `curl` and `jac` commands with the `jvcli` command-line tool. These changes streamline server operations, improve maintainability, and refine the logic for launching the file server in development mode.

## Description
### Command Replacement and Streamlining
- Replaced the `jac jvserve` command with `jvcli server launch` to start the main server process, simplifying command management.
- Substituted `curl` commands with `jvcli` for login, token extraction, and agent initialization, reducing the reliance on manual HTTP requests.
- Replaced `jac create_system_admin` with `jvcli server createadmin` to streamline system administrator creation.

### Logic Refinement
- Updated the file server launch condition:
  - Now checks both `JIVAS_ENVIRONMENT` and `JIVAS_FILEINTERFACE` variables.
  - Ensures the server only starts in development mode with a local file interface, preventing unnecessary launches in production.

## Changes Made
1. Switched from `jac` and `curl` to `jvcli` for various operations in `entrypoint.sh`.
2. Refined file server launch logic to restrict it to development mode with local file interface.