### PR TITLE
refactor to eliminate race condition leading to duplicate app nodes s…

### DIFF
--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.29"
+__version__ = "2.0.0-alpha.30"

--- a/jivas/agent/core/agent_graph_walker.jac
+++ b/jivas/agent/core/agent_graph_walker.jac
@@ -16,9 +16,7 @@ walker agent_graph_walker :graph_walker: {
     can on_app with App entry {
         # spawn agents node if not there
         visit [-->](`?Agents) else {
-            self.logger.debug('agents node created');
-            agents_node = here ++> Agents();
-            visit agents_node;
+            self.logger.error('App graph not initialized. Import an agent and try again.');
         }
     }
 

--- a/jivas/agent/core/graph_walker.jac
+++ b/jivas/agent/core/graph_walker.jac
@@ -17,6 +17,13 @@ walker graph_walker {
         static has private: bool = True;
     }
 
+    can on_root with `root entry {
+        # spawn app node if not there
+        visit [-->](`?App) else {
+            self.logger.error('App graph not initialized. Import an agent and try again.');
+        }
+    }
+
     can export(ignore_keys: list = ['__jac__']) {
         # convert the object to dictionary
         node_export = Utils.export_to_dict(self, ignore_keys);
@@ -40,15 +47,6 @@ walker graph_walker {
 
     can postupdate {
         # can be overriden to execute following a walker update
-    }
-
-    can on_root with `root entry {
-        # spawn app node if not there
-        visit [-->](`?App) else {
-            self.logger.debug('app node created');
-            app_node = here ++> App();
-            visit app_node;
-        }
     }
 
 }

--- a/jivas/agent/core/import_agent.jac
+++ b/jivas/agent/core/import_agent.jac
@@ -10,14 +10,14 @@ import:py from logging { Logger }
 import:py from jivas.agent.modules.agentlib.utils { Utils }
 import:py from jvcli.api { RegistryAPI }
 import:py from jvcli.utils { is_version_compatible }
+import:jac from app { App }
 import:jac from jivas.agent.core.agent { Agent }
 import:jac from agents { Agents }
-import:jac from agent_graph_walker { agent_graph_walker }
 import:jac from jivas.agent.memory.memory { Memory }
 import:jac from jivas.agent.action.action { Action }
 import:jac from jivas.agent.action.actions { Actions }
 
-walker import_agent :agent_graph_walker: {
+walker import_agent {
     # creates or refreshes an agent via json data or yaml source
 
     # set up logger
@@ -28,11 +28,48 @@ walker import_agent :agent_graph_walker: {
     has daf_version: str = "";
     has jpr_api_key: str = "";
     has reporting: bool = True;
-    has daf_archive:dict = {};
 
     obj __specs__ {
         # make this walker visible in API
         static has private: bool = False;
+    }
+
+    # sets up app graph on first time traversal prior to agent import
+
+    can on_root with `root entry {
+        # spawn app node if not there
+        visit [-->](`?App) else {
+            self.logger.info('App node created');
+            app_node = here ++> App();
+            visit app_node;
+        }
+    }
+
+    can on_app with App entry {
+        # spawn agents node if not there
+        visit [-->](`?Agents) else {
+            self.logger.info('Agents node created');
+            agents_node = here ++> Agents();
+            visit agents_node;
+        }
+    }
+
+    can on_agents with Agents entry {
+
+        # routine to import a JIVAS agent by descriptor
+        if(self.descriptor) {
+            if(agent_node := self.import_from_descriptor(here, self.descriptor)) {
+                if(self.reporting) {
+                    report agent_node.export();
+                }
+            }
+        } elif (self.daf_name) {
+            if(agent_node := self.import_from_daf(here, self.daf_name, self.daf_version, self.jpr_api_key)) {
+                if(self.reporting) {
+                    report agent_node.export();
+                }
+            }
+        }
     }
 
     can import_from_descriptor(agents_node:Agents, descriptor:str) -> Agent {
@@ -291,27 +328,7 @@ walker import_agent :agent_graph_walker: {
             }
         }
 
-
         return agent_node;
-    }
-
-    can on_agents with Agents entry {
-
-        # routine to import a JIVAS agent by descriptor
-        if(self.descriptor) {
-            if(agent_node := self.import_from_descriptor(here, self.descriptor)) {
-                if(self.reporting) {
-                    report agent_node.export();
-                }
-            }
-        } elif (self.daf_name) {
-            if(agent_node := self.import_from_daf(here, self.daf_name, self.daf_version, self.jpr_api_key)) {
-                if(self.reporting) {
-                    report agent_node.export();
-                }
-            }
-        }
-
     }
 
 }

--- a/jivas/agent/core/init_agents.jac
+++ b/jivas/agent/core/init_agents.jac
@@ -4,14 +4,12 @@ import:py io;
 import:py logging;
 import:py traceback;
 import:py from logging { Logger }
-import:jac from app { App }
-import:jac from jivas.agent.core.agent {Agent}
-import:jac from agents {Agents}
-import:jac from graph_walker {graph_walker}
+import:jac from agents { Agents }
+import:jac from agent_graph_walker { agent_graph_walker }
 import:jac from import_agent {import_agent}
 import:py from jivas.agent.modules.agentlib.utils { jvdata_file_interface }
 
-walker init_agents :graph_walker: {
+walker init_agents :agent_graph_walker: {
     # initializes agents on the graph using the existing file-based descriptor
 
     has reporting:bool = False;
@@ -22,15 +20,9 @@ walker init_agents :graph_walker: {
     obj __specs__ {
         # make this walker visible in API
         static has private: bool = False;
-    }
-
-    can on_app with App entry {
-        # spawn agents node if not there
-        visit [-->](`?Agents) else {
-            self.logger.debug('agents node created');
-            agents_node = here ++> Agents();
-            visit agents_node;
-        }
+        static has excluded: list = [
+            "agent_id" # inherited agent_id not relevant for list agents params
+        ];
     }
 
     can on_agents with Agents entry {

--- a/jivas/agent/core/list_agents.jac
+++ b/jivas/agent/core/list_agents.jac
@@ -1,22 +1,16 @@
-import:jac from graph_walker { graph_walker }
+import:jac from agent_graph_walker { agent_graph_walker }
 import:jac from app { App }
 import:jac from agents { Agents }
 
-walker list_agents :graph_walker: {
+walker list_agents :agent_graph_walker: {
     # lists all agents in the graph
 
     obj __specs__ {
         # make this walker visible in API
         static has private: bool = False;
-    }
-
-    can on_app with App entry {
-        # spawn agents node if not there
-        visit [-->](`?Agents) else {
-            self.logger.debug('agents node created');
-            agents_node = here ++> Agents();
-            visit agents_node;
-        }
+        static has excluded: list = [
+            "agent_id" # inherited agent_id not relevant for list agents params
+        ];
     }
 
     can on_agents with Agents entry {

--- a/jivas/agent/core/update_agent.jac
+++ b/jivas/agent/core/update_agent.jac
@@ -7,7 +7,7 @@ import:jac from export_agent { export_agent }
 import:jac from jivas.agent.core.agent { Agent }
 
 walker update_agent :agent_graph_walker: {
-    has agent_id: str = "";
+
     has agent_data: dict = {};
     has with_actions: bool = False; # set True if you'd like actions to be re-registered with this update
     has reporting: bool = True;


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
This PR refactors the code to eliminate a race condition that led to duplicate app nodes being spawned upon agent import.

---

## **Description**
### **Refactor Request**:
- **Specific Area Refactored**: The base walker code responsible for node spawning.
- **Problem with Current Implementation**: The existing setup caused a race condition due to multiple walker derivatives potentially executing during the agent import, making the conditional check for node presence ineffective.
- **Improvements Made**: Ensured that only the import agent walker is responsible for setting up the app graph nodes, preventing any competing operations by walker children.

---

## **Changes Made**
### High-Level Summary:
1. Refactored the base walker to restrict node setup to the import agent walker.
2. Removed competing operations from walker children.
3. Improved sequence handling of graph changes for node spawning.

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Provide a clear set of steps for testing the changes introduced in this PR:
1. Execute the import of an agent.
2. Verify that only a single app node and agent node are spawned.
3. Confirm that no race conditions occur during the process.

---

## **Additional Context**
No additional context provided.

---

## **Questions or Concerns**
None.
