### PR TITLE
Alpha.31

### DIFF
--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.30"
+__version__ = "2.0.0-alpha.31"

--- a/jivas/agent/action/action.jac
+++ b/jivas/agent/action/action.jac
@@ -88,7 +88,7 @@ node Action :GraphNode: {
             }
         }
         # update the agent descriptor with changes
-        self.get_agent().export_descriptor();
+        self.get_agent().dump_descriptor();
         # trigger postupdate
         self.postupdate();
 

--- a/jivas/agent/action/exit_interact_action.jac
+++ b/jivas/agent/action/exit_interact_action.jac
@@ -7,7 +7,6 @@ node ExitInteractAction :InteractAction: {
 # it serves to directly reference with take to force the interact walker to exit and return
     has label: str = "ExitInteractAction";
     has description: str = "core exit action node for walker cleanup and return";
-    has graph_self: bool = False; # prevent from graphing
     has weight:int = 10000; # should always be last
 
     can touch(visitor: interact_graph_walker) -> bool {

--- a/jivas/agent/action/install_action.jac
+++ b/jivas/agent/action/install_action.jac
@@ -116,7 +116,7 @@ walker install_action :agent_graph_walker: {
                 data=descriptor,
                 with_actions=True
             )) {
-                agent_node.export_descriptor();
+                agent_node.dump_descriptor();
                 return agent_node;
             }
         }

--- a/jivas/agent/action/interact.jac
+++ b/jivas/agent/action/interact.jac
@@ -223,7 +223,7 @@ walker interact :interact_graph_walker: {
             message_window = {key: utc.localize(value) if isinstance(value, datetime) else datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f") for key, value in message_window.items() if key in keys};
             ::py::
 
-            if (message_window.get("end", 0) <= now) {
+            if (utc.localize(message_window.get("end", 0)) <= now) {
                 # reset window
                 message_window["start"] = now;
                 message_window["end"] = now + timedelta(seconds=window_time);

--- a/jivas/agent/action/vector_store_action.jac
+++ b/jivas/agent/action/vector_store_action.jac
@@ -6,7 +6,7 @@ import:py traceback;
 import:py from typing { Any, Tuple }
 import:py from logging { Logger }
 import:jac from action { Action }
-import:py from jivas.agent.modules.agentlib.utils { LongStringDumper }
+import:py from jivas.agent.modules.agentlib.utils { Utils }
 import:jac from interact_graph_walker {interact_graph_walker}
 import:py from langchain_community.document_loaders { TextLoader }
 import:py from langchain_text_splitters { CharacterTextSplitter }
@@ -158,7 +158,7 @@ node VectorStoreAction :Action: {
         }
     }
 
-    can export_knodes(export_json:bool = False, embeddings:bool = True, include_id:bool = False) -> str {
+    can export_knodes(as_json:bool = False, embeddings:bool = False, with_ids:bool = False) -> str {
         # """
         # Export all documents from the vectorstore as knodes.
 
@@ -167,12 +167,14 @@ node VectorStoreAction :Action: {
         try {
 
             if(collection := self.get_collection(self.collection_name)) {
+
                 excluded_fields = '';
-                if include_id {
+
+                if with_ids {
                     if(not embeddings) {
                         excluded_fields = 'vec';
                     }
-                }else{
+                } else {
                     excluded_fields = 'id,vec';
                     if(embeddings) {
                         excluded_fields = 'id';
@@ -213,10 +215,10 @@ node VectorStoreAction :Action: {
                     }
                 }
 
-                if(export_json) {
+                if(as_json) {
                     return json.dumps(documents);
-                }else{
-                    return yaml.dump(documents, Dumper=LongStringDumper);
+                } else {
+                    return Utils.yaml_dumps(documents);
                 }
             }
 

--- a/jivas/agent/core/agent.jac
+++ b/jivas/agent/core/agent.jac
@@ -1,13 +1,14 @@
 import:py logging;
 import:py traceback;
 import:py from logging { Logger }
-import:py from jivas.agent.modules.agentlib.utils { Utils }
+import:py from jivas.agent.modules.agentlib.utils { Utils, jvdata_file_interface }
 import:jac from jivas.agent.core { graph_node, purge }
 import:jac from graph_node { GraphNode }
 import:jac from jivas.agent.action.action { Action }
 import:jac from jivas.agent.action.interact_action { InteractAction }
 import:jac from jivas.agent.action.actions { Actions }
 import:jac from jivas.agent.memory.memory { Memory }
+import:py from typing { Union }
 
 node Agent :GraphNode: {
     # represents an agent on the graph
@@ -35,7 +36,7 @@ node Agent :GraphNode: {
     can postinit {
         super.postinit();
         # node attributes which are protected from update operation
-        self.protected_attrs += ["id", "actions", "descriptor", "healthcheck_status", "meta"];
+        self.protected_attrs += ["id", "actions", "descriptor", "healthcheck_status"];
     }
 
     can get_memory() {
@@ -143,34 +144,33 @@ node Agent :GraphNode: {
         self.agent_logging = agent_logging;
     }
 
-    can export_descriptor(file_path: str="", modified_context:bool=False) -> dict {
-        # converts an agent to a descriptor and exports it...
-        # if file_path is provided, it will output to specified file path
-        # otherwise, it will output to agent's descriptor path
-        # returns descriptor dict.
+    can get_descriptor(as_yaml:bool=False, clean:bool=False) -> Union[str, dict] {
+        # converts an agent to a descriptor and returns it as yaml, json or dict (default)
+        # if 'clean' is set to True, descriptor data will be without snapshot state containing keys and configs (good for dafs)
         try  {
-            self.logger.debug(f"exporting agent: {self.name}");
-
-            agent_data = self.export([], modified_context);
+            agent_data = {};
             agent_actions = [];
-            # Gather agent actions
-            agent_actions = (self spawn _export_actions(modified_context=modified_context)).action_nodes;
+            agent_ignore_keys = [];
+            action_ignore_keys = ['_package'];
 
-            # Add agent actions to agent data
+            if(clean) {
+                agent_ignore_keys = self.protected_attrs + ['meta'];
+                action_ignore_keys = [
+                    'id', 'description', '_package', 'weight', 'api_key', 'secret_key', 'token',
+                    "host", "port", "protocol", "api_key_name", "connection_timeout", "collection_name"
+                ];
+            }
 
+            # get agent data
+            agent_data = self.export(agent_ignore_keys, clean);
+            # get action data
+            agent_actions = (self spawn _export_actions(action_ignore_keys, clean)).action_nodes;
+            # add agent actions to agent data
             agent_data = {**agent_data, **{"actions": agent_actions}};
 
-            # Save agent state to file
-            if (file_path) {
-                Utils.dump_yaml_file(
-                    file_path=file_path,
-                    data=agent_data
-                );
-            } else {
-                Utils.dump_yaml_file(
-                    file_path=self.descriptor,
-                    data=agent_data
-                );
+            # return as YAML
+            if (as_yaml) {
+                return Utils.yaml_dumps(agent_data);
             }
 
             return agent_data;
@@ -182,6 +182,40 @@ node Agent :GraphNode: {
         }
 
         return {};
+    }
+
+    can get_daf_info() -> dict {
+        # prepares daf info struct based on agent descriptor
+        daf_info = {
+            "package": {
+                "name": self.meta.get('namespace', f'default/{Utils.to_snake_case(self.name)}'),
+                "author": self.meta.get('author', ''),
+                "version": self.meta.get('version', '0.0.1'),
+                "meta": {
+                    "title": self.name,
+                    "description": self.description,
+                    "type": "daf"
+                }
+            }
+        };
+        if(dependencies := self.meta.get('dependencies')) {
+            daf_info["package"]["dependencies"] = dependencies;
+        }
+
+        return daf_info;
+    }
+
+    can dump_descriptor() {
+        # exports agent and writes descriptor to .jvdata
+
+        # get agent descriptor data
+        agent_data = self.get_descriptor(clean=False);
+        # Save agent state to file in .jvdata
+        if (yaml_output := Utils.yaml_dumps(agent_data)) {
+            jvdata_file_interface.save_file(self.descriptor, yaml_output.encode("utf-8"));
+        } else {
+            self.logger.error("Unable to dump agent descriptor to file");
+        }
     }
 
     can healthcheck() -> Union[bool, dict] {
@@ -364,10 +398,10 @@ walker _healthcheck_actions {
 walker _export_actions {
     # retrieves a list of all actions and sub actions
     # must be spawned on agent or actions node
-    has transient_export_attrs:list = ['_package'];
+    has ignore_keys:list = ['_package'];
     has action_nodes: list = [];
     has node_index: dict = {};
-    has modified_context: bool = False;
+    has clean: bool = False;
 
     obj __specs__ {
         # make this a private walker
@@ -400,7 +434,7 @@ walker _export_actions {
             self.node_index.update({
                 here.id: {
                     "action": here._package['name'],
-                    "context": here.export(self.transient_export_attrs, self.modified_context),
+                    "context": here.export(self.ignore_keys, self.clean),
                     "children": children
                 }
             });

--- a/jivas/agent/core/export_daf.jac
+++ b/jivas/agent/core/export_daf.jac
@@ -1,0 +1,93 @@
+import:py io;
+import:py zipfile;
+import:jac from agent_graph_walker { agent_graph_walker }
+import:jac from jivas.agent.core.agent { Agent }
+import:jac from jivas.agent.action.action { Action }
+import:jac from jivas.agent.action.actions { Actions }
+import:py from jivas.agent.modules.agentlib.utils { Utils, public_file_interface }
+
+
+walker export_daf :agent_graph_walker: {
+    # exports and packages an agent daf, saves it to file and returns the URL for download
+
+    has clean:bool = False;
+    has with_knowledge: bool = True;
+    has with_memory: bool = False;
+
+    obj __specs__ {
+        # make this walker visible in API
+        static has private: bool = False;
+    }
+
+    can on_agent with Agent entry {
+
+        daf_contents = {};
+
+        daf_name = here.meta.get('namespace', 'agent_daf');
+        # prepare the daf info
+        daf_info_yaml = Utils.yaml_dumps( here.get_daf_info() );
+        # prepare the agent descriptor
+        daf_descriptor_yaml = here.get_descriptor(as_yaml=True, clean=self.clean);
+
+        if(daf_info_yaml and daf_descriptor_yaml) {
+            daf_contents = {
+                "info.yaml" : daf_info_yaml,
+                "descriptor.yaml": daf_descriptor_yaml,
+            };
+        } else {
+            Jac.get_context().status = 503;
+            report "no valid daf info or descriptor generated, unable to complete export";
+            disengage;
+        }
+
+        if(self.with_memory) {
+            # prepare memory descriptor
+            daf_memory_data = here.get_memory().export_memory();
+            if( daf_memory_yaml := Utils.yaml_dumps(daf_memory_data)) {
+                daf_contents['memory.yaml'] = daf_memory_yaml;
+            } else {
+                self.logger.error("Unable to export memory. It may be blank or there may be a YAML conversion issue.");
+            }
+        }
+
+        if(self.with_knowledge) {
+            # prepare knowledge
+            daf_knowledge = [];
+            try {
+                if(vector_store_action := here.get_actions().get(action_label = here.get_vector_store_action())) {
+                    if( daf_knowledge_yaml := vector_store_action.export_knodes()) {
+                        daf_contents['knowledge.yaml'] = daf_knowledge_yaml;
+                    } else {
+                        self.logger.error("Unable to export knowledge. It may be blank or there may be a YAML conversion issue.");
+                    }
+                }
+            } except Exception as e {
+                Jac.get_context().status = 503;
+                error_message = f"Unable to export knowledge : {e}";
+                self.logger.error(error_message);
+                report error_message;
+                disengage;
+            }
+        }
+
+        # let's output and archive the zipfile as bytes
+        buffer = io.BytesIO();
+        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zipf {
+            for (fname, content) in daf_contents.items() {
+                zipf.writestr(fname, content);
+            }
+        }
+        daf_bytes = buffer.getvalue();
+        daf_output_filename = f"dafs/{daf_name.replace('/','_')}.daf.zip";
+        if( public_file_interface.save_file(daf_output_filename, daf_bytes) ) {
+            Jac.get_context().status = 200;
+            # return the fileserved URL
+            report public_file_interface.get_file_url(daf_output_filename);
+        } else {
+            Jac.get_context().status = 503;
+            error_message = "There was a problem generating the DAF";
+            self.logger.error(error_message);
+            report error_message;
+        }
+    }
+}

--- a/jivas/agent/core/export_descriptor.jac
+++ b/jivas/agent/core/export_descriptor.jac
@@ -3,8 +3,11 @@ import:jac from jivas.agent.core.agent { Agent }
 import:jac from jivas.agent.action.action { Action }
 import:jac from jivas.agent.action.actions { Actions }
 
-walker export_agent :agent_graph_walker: {
-    # accepts agent_id and returns dict of exported agent descriptor
+walker export_descriptor :agent_graph_walker: {
+    # accepts agent_id and returns dict / yaml of exported agent descriptor
+
+    has as_yaml: bool = False;
+    has clean:bool = False;
 
     obj __specs__ {
         # make this walker visible in API
@@ -12,8 +15,6 @@ walker export_agent :agent_graph_walker: {
     }
 
     can on_agent with Agent entry {
-        if(self.reporting) {
-            report here.export_descriptor();
-        }
+        report here.get_descriptor(as_yaml=self.as_yaml, clean=self.clean);
     }
 }

--- a/jivas/agent/core/graph_node.jac
+++ b/jivas/agent/core/graph_node.jac
@@ -33,24 +33,31 @@ node GraphNode {
         return type(super()).__name__;
     }
 
-    can export(ignore_keys: list = [], modified_context: bool = False) -> dict {
+    can export(ignore_keys: list = [], clean: bool = False) -> dict {
+        # exports graph node as dict; if clean is set, exports a snapshot of node which matches architype initializations
 
-        if(modified_context) {
+        if(clean) {
             ignore_keys = ignore_keys + self.transient_attrs;
 
-            cls = type(self);
-            default_values = {};
-            for f in fields(self){
-                if f.default is not MISSING{
-                    default_values[f.name] = f.default;
+            architype_context = {};
+            for f in fields(self) {
+                if f.default is not MISSING {
+                    architype_context[f.name] = f.default;
                 }
-                elif f.default_factory is not MISSING{
-                    default_values[f.name] = f.default_factory();
+                elif f.default_factory is not MISSING {
+                    architype_context[f.name] = f.default_factory();
                 }
             }
 
             node_export = Utils.export_to_dict(self, ignore_keys);
-            return Utils.sanitize_dict_context(descriptor_data = node_export, action_data = default_values, keys_to_remove= ignore_keys);
+            # we have to merge contents of _context into top-level dict; _context contains injected attributes
+            if (isinstance(node_export['_context'], dict)) {
+                node_export.update(node_export['_context']);
+                # now remove the original _context
+                del node_export['_context'];
+            }
+
+            return Utils.clean_context(node_context=node_export, architype_context=architype_context, ignore_keys=ignore_keys);
 
         } else {
             # set the keys to ignore

--- a/jivas/agent/core/graph_node.jac
+++ b/jivas/agent/core/graph_node.jac
@@ -8,14 +8,10 @@ import:py from dataclasses { fields, MISSING }
 node GraphNode {
     # base graph node for all nodes in agent graph, under app node.
     has id: str = "";
-    # flag to permit export of children nodes in agent graph export
-    has graph_children: bool = False;
-    # flag to permit export of itself in agent graph export
-    has graph_self: bool = True;
     # list of node attributes which are protected from update operation
     has protected_attrs: list = ["id"];
     # list of node attributes which should be excluded from export
-    has transient_attrs: list = ['__jac__', 'protected_attrs', 'transient_attrs', 'graph_children', 'graph_self', 'package_path'];
+    has transient_attrs: list = ['__jac__', 'protected_attrs', 'transient_attrs', 'package_path'];
     # for storing extended attributes
     has _context: dict = {};
     # set up logger

--- a/jivas/agent/core/import_agent.jac
+++ b/jivas/agent/core/import_agent.jac
@@ -6,6 +6,7 @@ import:py requests;
 import:py tarfile;
 import:py logging;
 import:py traceback;
+import:py from typing { Union }
 import:py from logging { Logger }
 import:py from jivas.agent.modules.agentlib.utils { Utils }
 import:py from jvcli.api { RegistryAPI }
@@ -72,8 +73,9 @@ walker import_agent {
         }
     }
 
-    can import_from_descriptor(agents_node:Agents, descriptor:str) -> Agent {
-        # imports an agent from an agent descriptor
+    can import_from_descriptor(agents_node:Agents, descriptor:Union[str, dict]) -> Agent {
+        # imports an agent from an agent descriptor supplied as YAML, JSON or dict
+
         agent_data = {};
         agent_node = None;
 
@@ -94,7 +96,7 @@ walker import_agent {
                 agent_data = yaml.safe_load(descriptor);
             } except yaml.YAMLError {}
 
-        }else{
+        } else {
             agent_data = descriptor;
         }
 
@@ -113,8 +115,7 @@ walker import_agent {
                 return None;
             }
 
-        }
-        else {
+        } else {
             agent_name = agent_data.get('name');
             # if agent has same name as existing agent, update
             if(_node := agents_node.get_by_name(agent_name)) {
@@ -152,7 +153,7 @@ walker import_agent {
                 with_actions=True
             )) {
                 # write out descriptor
-                agent_node.export_descriptor();
+                agent_node.dump_descriptor();
                 return agent_node;
             }
 
@@ -165,6 +166,7 @@ walker import_agent {
         # imports the agent as a digital agent freight package
         agent_node = None;
         safe_to_import = False;
+        daf_info = {};
         # daf packages root folder
         package_root = Utils.get_daf_root();
         # extract the namespace, package name
@@ -179,10 +181,9 @@ walker import_agent {
                 with open(info_yaml_path, 'r') as file {
                     try  {
                         # load the package info content
-                        _info = yaml.safe_load(file);
+                        daf_info = yaml.safe_load(file);
                         # grab info package version
-                        package_version = _info.get('package', {}).get('version', None);
-
+                        package_version = daf_info.get('package', {}).get('version', None);
                         # validate the version, if present
                         if(version) {
                             if(is_version_compatible(version, package_version)) {
@@ -191,7 +192,6 @@ walker import_agent {
                         } else {
                             safe_to_import = True;
                         }
-
                     } except yaml.YAMLError as e {
                         self.logger.error(
                             f"an exception occurred, {traceback.format_exc()}"
@@ -209,7 +209,6 @@ walker import_agent {
 
                 try {
                     package_file = requests.get(package_data["file"]);
-
                     # Save and extract the package
                     target_dir = os.path.join(package_root, daf_name);
                     os.makedirs(target_dir, exist_ok=True);
@@ -238,18 +237,11 @@ walker import_agent {
             descriptor_yaml_path = os.path.join(package_path, 'descriptor.yaml');
             memory_yaml_path = os.path.join(package_path, 'memory.yaml');
             knowledge_yaml_path = os.path.join(package_path, 'knowledge.yaml');
-            meta = {};
 
             if(os.path.exists(info_yaml_path)) {
                 with open(info_yaml_path, 'r') as file {
                     try  {
-                        info_yaml = yaml.safe_load(file);
-                        meta = {
-                            "namespace": info_yaml['package']['name'],
-                            "version": info_yaml['package']['version'],
-                            "author": info_yaml['package']['author'],
-                            "dependencies": info_yaml['package']['dependencies']
-                        };
+                        daf_info = yaml.safe_load(file);
                     } except Exception as e {
                         self.logger.error(
                             f"an exception occurred, {traceback.format_exc()}"
@@ -263,9 +255,17 @@ walker import_agent {
             if(os.path.exists(descriptor_yaml_path)) {
                 with open(descriptor_yaml_path, 'r') as file {
                     try  {
-                        descriptor_yaml = yaml.safe_load(file);
-                        descriptor_yaml["meta"] = meta;
-                        agent_node = self.import_from_descriptor(agents_node, yaml.dump(descriptor_yaml));
+                        descriptor_data = yaml.safe_load(file);
+                        # add the daf info as metadata
+                        descriptor_data["meta"] = {
+                            "namespace": daf_info.get('package', {}).get('name'),
+                            "version": daf_info.get('package', {}).get('version'),
+                            "author": daf_info.get('package', {}).get('author'),
+                            "dependencies": daf_info.get('package', {}).get('dependencies')
+                        };
+
+                        agent_node = self.import_from_descriptor(agents_node, descriptor_data);
+
                     } except Exception as e {
                         self.logger.error(
                             f"an exception occurred, {traceback.format_exc()}"
@@ -279,7 +279,7 @@ walker import_agent {
             if(agent_node) {
                 if(agent_node.healthcheck_status != 200) {
                     self.logger.error(
-                        f"{agent_node.name} failed healthcheck. Any memory or knowledge packaged for import will be deferred."
+                        f"{agent_node.name} failed healthcheck. Any memory or knowledge queued for import will be deferred."
                     );
                     return agent_node;
                 }

--- a/jivas/agent/core/update_agent.jac
+++ b/jivas/agent/core/update_agent.jac
@@ -3,7 +3,6 @@ import:py traceback;
 import:py from logging { Logger }
 import:py from jivas.agent.modules.agentlib.utils { Utils }
 import:jac from agent_graph_walker { agent_graph_walker }
-import:jac from export_agent { export_agent }
 import:jac from jivas.agent.core.agent { Agent }
 
 walker update_agent :agent_graph_walker: {
@@ -25,7 +24,7 @@ walker update_agent :agent_graph_walker: {
         if(agent_node := here.update(data = self.agent_data, with_actions = self.with_actions)) {
             if(agent_node) {
                 if(self.reporting) {
-                    report agent_node.export_descriptor();
+                    report agent_node.get_descriptor();
                 }
             } else {
                 self.logger.error(f'unable to update agent');

--- a/jivas/agent/lib.jac
+++ b/jivas/agent/lib.jac
@@ -3,7 +3,8 @@
 import:jac from jivas.agent.core {
     init_agents,
     import_agent,
-    export_agent,
+    export_descriptor,
+    export_daf,
     get_agent,
     update_agent,
     list_agents,

--- a/jivas/agent/memory/interaction_response.jac
+++ b/jivas/agent/memory/interaction_response.jac
@@ -18,7 +18,7 @@ obj InteractionMessage {
 
     can load(data:dict) {
         # loads a compatible interaction message data struct
-        if (data) {
+        if (data and isinstance(data, dict)) {
             for attr in data.keys() {
                 # set if attribute is a valid attribute
                 if (hasattr(self, attr)) {

--- a/jivas/agent/memory/memory.jac
+++ b/jivas/agent/memory/memory.jac
@@ -21,6 +21,7 @@ node Memory :GraphNode: {
 
     can get_frame(agent_id:str, session_id:str, force_session:bool=False, lookup:bool=False) -> Frame {
         # attempt to retrieve an existing session or spawn then traverse to a new one if force is on
+        # if lookup is on, it operates in search mode
 
         frame_node = Utils.node_obj( [-->](`?Frame)(?session_id == session_id) );
 
@@ -37,27 +38,33 @@ node Memory :GraphNode: {
         return frame_node;
     }
 
-    can get_frames() -> list[Frame] {
-        # returns a list of all frame nodes attached to memory
+    can get_frames(session_id:str="") -> list[Frame] {
+        # returns a list of all frame nodes attached to memory or specific ones by session_id if supplied
+
+        if session_id {
+            return [-->](`?Frame)(?session_id == session_id);
+        }
+
         return [-->](`?Frame);
     }
 
-    can import_memory(data:dict, overwrite:bool=True) {
+    can import_memory(data:dict, overwrite:bool=True) -> bool {
         # imports a structured memory dump into memory
         # set overwrite to True in order to wipe memory first
         if not data or not isinstance(data, dict) {
             return False;
         }
 
-        if overwrite {
-            # first purge memory
-            self.purge();
-        }
-
-        # grab agent node
-        agent_node = self.get_agent();
-
         try {
+
+            if overwrite {
+                # first purge memory
+                self.purge();
+            }
+
+            # grab agent node
+            agent_node = self.get_agent();
+
             for frame_data in data.get('memory') {
 
                 # add the session id if we can grab it
@@ -68,7 +75,8 @@ node Memory :GraphNode: {
                     # add the properties under context
                     frame_node.update(frame_data.get('frame', {}).get('context', {}));
 
-                    for interaction_data in frame_data.get('frame', {}).get('interactions', []) {
+                    interactions = frame_data.get('frame', {}).get('interactions', []);
+                    for interaction_data in interactions {
                         # get last interaction node
                         last_interaction_node = frame_node.get_last_interaction();
                         # create the interaction node
@@ -89,6 +97,7 @@ node Memory :GraphNode: {
             }
 
             return True;
+
         } except Exception as e {
             self.logger.warning(f"uploaded memory failed: {e}");
         }
@@ -96,27 +105,29 @@ node Memory :GraphNode: {
         return False;
     }
 
-    can export_memory(agent_id:str, session_id:str, json:bool, save_to_file:bool) {
-        # return a structured memory dump
-        return (self spawn _export_memory(agent_id=agent_id, session_id=session_id, json=json, save_to_file=save_to_file)).frame_data;
+    can export_memory(session_id:str="") {
+        # return a structured memory dump of all agent frames or only those with session_id if supplied
+        return (self spawn _export_memory(session_id=session_id)).frame_data;
     }
 
-    can memory_healthcheck(agent_id:str, session_id:str = "", verbose:bool=False) {
+    can memory_healthcheck(session_id:str = "") {
+
         # init stats
-        total_users = 0;
+        total_frames = 0;
         total_interactions = 0;
 
-        # grab all frames and count length
-        total_users = len(self.get_frames());
+        # grab frames and count length
+        frames = self.get_frames(session_id);
+        total_frames = len(frames);
 
         # loop through frames and count interactions
-        for user in self.get_frames() {
+        for frame in frames {
             # count interactions and add to total
-            total_interactions += len(user.get_interactions());
+            total_interactions += len(frame.get_interactions());
         }
 
         return {
-            "total_users": total_users,
+            "total_frames": total_frames,
             "total_interactions": total_interactions
         };
     }
@@ -175,20 +186,13 @@ walker _purge {
 }
 
 walker _export_memory {
-    # walker which carries out the traversal and purging of frames and related interactions
+    # visits all frames which belong to an optional session_id and returns them and related interactions
 
     # set up logger
     static has logger:Logger = logging.getLogger(__name__);
 
-    has status:int = 200;
-    has response:str = "";
-    has session_id:str = "";
-    has agent_id:str = ""; # TODO: Add agent id validation
+    has session_id:str = ""; # optional, if not supplied, all frames will be exported
     has frame_data:dict = {}; # dict with id of frame as key mapping to all interactions on that frame
-    has file_url:str = "";
-    has file_path:str = "";
-    has json:bool = false;
-    has save_to_file:bool = false;
 
     obj __specs__ {
         # make this a private walker
@@ -201,28 +205,26 @@ walker _export_memory {
             "memory": []
         };
 
-        # navigate to frames
         if(self.session_id) {
-            # only export the session
+            # if session_id is supplied, filter frames
             visit [-->](`?Frame)(?session_id == self.session_id);
         } else {
-            # export all frames
+            # otherwise export all frames
             visit [-->](`?Frame);
         }
     }
 
     can on_frame with Frame entry {
 
-        # grab interactions object
-        interactions = here.get_interactions();
+        interaction_data = [];
 
-        # init interactions
-        interaction_nodes = [];
+        # grab interactions
+        interactions = here.get_interactions();
 
         # fix interaction object by exporting what we
         for interaction_node in interactions {
             # add to interactions
-            interaction_nodes.append({"interaction": {"context": interaction_node.export()}});
+            interaction_data.append({"interaction": {"context": interaction_node.export()}});
         }
 
         # grab interactions and add to frame data
@@ -230,36 +232,11 @@ walker _export_memory {
             {
                 "frame": {
                     "context": here.export(),
-                    "interactions": interaction_nodes
+                    "interactions": interaction_data
                 }
             }
         );
 
     }
 
-    can export_memory with exit {
-        # load env variables from .env file
-        dotenv.load_dotenv();
-
-        # output the yaml
-        if(None) {
-            # create file path
-            file_name = f"memory/{str(uuid.uuid4())}";
-
-            if(not self.json){
-                # set file path
-                self.file_path = f"{file_name}.yaml";
-
-                # write to file
-                Utils.dump_yaml_file(self.file_path, self.frame_data);
-            }else{
-                # set file path
-                self.file_path = f"{file_name}.json";
-
-                # write to file
-                Utils.dump_json_file(self.file_path, self.frame_data);
-            }
-
-        }
-    }
 }

--- a/tests/agent/modules/agentlib/test_utils.py
+++ b/tests/agent/modules/agentlib/test_utils.py
@@ -1128,3 +1128,78 @@ class TestUtils:
         )
         d = {"a": 1}
         assert Utils.yaml_dumps(d) is None
+
+    def test_normalize_text_basic(self) -> None:
+        """Test that normalize_text handles basic cases."""
+        # Arrange
+        input_text = "  This is a   test.   "
+        expected_output = "Thisisatest"
+
+        # Act
+        result = Utils.normalize_text(input_text)
+
+        # Assert
+        assert result == expected_output
+
+    def test_clean_context_match_and_remove(self) -> None:
+        """Test that matching keys/values are removed."""
+        # Arrange
+        node_context = {"key1": "value", "key2": "another"}
+        architype_context = {"key1": "value", "key2": "different"}
+        ignore_keys: list[str] = []
+
+        # Act
+        result = Utils.clean_context(node_context, architype_context, ignore_keys)
+
+        # Assert
+        assert result == {"key2": "another"}
+
+    def test_clean_context_remove_empty_values(self) -> None:
+        """Test that empty values are removed."""
+        # Arrange
+        node_context: dict = {"key1": "", "key2": None, "key3": [], "key4": False}
+        architype_context: dict = {}
+        ignore_keys: list[str] = []
+
+        # Act
+        result = Utils.clean_context(node_context, architype_context, ignore_keys)
+
+        # Assert
+        assert result == {"key4": False}
+
+    def test_clean_context_ignore_keys(self) -> None:
+        """Test that keys in ignore_keys are removed."""
+        # Arrange
+        node_context = {"key1": "value", "key2": "another"}
+        architype_context = {"key1": "different"}
+        ignore_keys: list[str] = ["key1"]
+
+        # Act
+        result = Utils.clean_context(node_context, architype_context, ignore_keys)
+
+        # Assert
+        assert result == {"key2": "another"}
+
+    def test_to_snake_case_basic(self) -> None:
+        """Test that to_snake_case converts a title to snake case."""
+        # Arrange
+        input_title = "Test Title for Conversion"
+        expected_output = "test_title_for_conversion"
+
+        # Act
+        result = Utils.to_snake_case(input_title)
+
+        # Assert
+        assert result == expected_output
+
+    def test_to_snake_case_strip_non_ascii(self) -> None:
+        """Test that to_snake_case strips non-ASCII characters when ascii_only is True."""
+        # Arrange
+        input_title = "Tést Tïtle wîth âccêntš"
+        expected_output = "test_title_with_accents"
+
+        # Act
+        result = Utils.to_snake_case(input_title)
+
+        # Assert
+        assert result == expected_output

--- a/tests/agent/modules/agentlib/test_utils.py
+++ b/tests/agent/modules/agentlib/test_utils.py
@@ -1103,14 +1103,6 @@ class TestUtils:
         assert "- 2" in yml
         assert "b: (1, 2)" in yml
 
-    def test_yaml_dumps_empty_dict(self) -> None:
-        """Test yaml_dumps returns None for an empty dictionary."""
-        assert Utils.yaml_dumps({}) is None
-
-    def test_yaml_dumps_none(self) -> None:
-        """Test yaml_dumps returns None for None input."""
-        assert Utils.yaml_dumps(None) is None
-
     def test_yaml_dumps_non_serializable(self) -> None:
         """Test yaml_dumps serializes dicts with custom object values."""
         d = {"foo": Dummy()}

--- a/tests/agent/modules/agentlib/test_utils.py
+++ b/tests/agent/modules/agentlib/test_utils.py
@@ -1,7 +1,7 @@
 """Tests for jivas.agent.modules.agentlib.utils."""
 
 import os
-import time
+import types
 from datetime import datetime
 from typing import Any, Dict
 from uuid import UUID
@@ -16,6 +16,14 @@ from jivas.agent.modules.agentlib.utils import (
     LongStringDumper,
     Utils,
 )
+
+
+class Dummy:
+    """A dummy class for testing custom object serialization."""
+
+    def __str__(self) -> str:
+        """Returns the dummy instance."""
+        return "DummyInstance"
 
 
 class TestUtils:
@@ -129,55 +137,6 @@ class TestUtils:
         # Assert
         assert result == ""
         mock_makedirs.assert_called_once_with("")
-
-    def test_write_dict_to_yaml_file(self, tmp_path: Any) -> None:
-        """Test writing dictionary data to YAML file."""
-        # Arrange
-        test_file = tmp_path / "test.yaml"
-        test_data: Dict[str, str] = {"key1": "value1", "key2": "value2"}
-
-        # Act
-        Utils.dump_yaml_file(str(test_file), test_data)
-
-        # Assert
-        assert test_file.exists()
-        with open(test_file) as f:
-            loaded_data = yaml.safe_load(f)
-        assert loaded_data == test_data
-
-    def test_write_empty_dict_to_yaml(self, tmp_path: Any) -> None:
-        """Test writing empty dictionary to YAML file."""
-        # Arrange
-        test_file = tmp_path / "empty.yaml"
-        test_data: Dict[str, Any] = {}
-
-        # Act
-        Utils.dump_yaml_file(str(test_file), test_data)
-
-        # Assert
-        assert test_file.exists()
-        with open(test_file) as f:
-            loaded_data = yaml.safe_load(f)
-        assert loaded_data == test_data
-
-    def test_ioerror_exception_handling(self, mocker: MockerFixture) -> None:
-        """Test that IOError is handled correctly when writing to a file."""
-        # Arrange
-        file_path = "invalid/path/to/file.yaml"
-        data = {"key": "value"}
-        mock_open = mocker.patch("builtins.open", side_effect=IOError)
-        mock_logger_error = mocker.patch(
-            "jivas.agent.modules.agentlib.utils.logger.error"
-        )
-
-        # Act
-        Utils.dump_yaml_file(file_path, data)
-
-        # Assert
-        mock_open.assert_called_once_with(file_path, "wb")
-        mock_logger_error.assert_called_once_with(
-            f"Error writing to descriptor file {file_path}"
-        )
 
     def test_convert_path_with_multiple_segments(self) -> None:
         """Test converting a path with multiple segments to module path."""
@@ -1049,67 +1008,6 @@ class TestUtils:
         # Assert
         assert result == input_data
 
-    def test_delete_old_files(self, tmp_path: Any, mocker: MockerFixture) -> None:
-        """Test deleting files older than specified days."""
-        # Arrange
-        test_dir = tmp_path / "test_dir"
-        test_dir.mkdir()
-        test_file = test_dir / "old_file.txt"
-        test_file.write_text("test content")
-
-        # Mock time functions
-        current_time = time.time()
-        old_time = current_time - (31 * 86400)  # 31 days old
-        mocker.patch(
-            "jivas.agent.modules.agentlib.utils.os.path.getmtime", return_value=old_time
-        )
-        mocker.patch(
-            "jivas.agent.modules.agentlib.utils.time.time", return_value=current_time
-        )
-
-        # Act
-        Utils.delete_files(str(test_dir), days=30)
-
-        # Assert
-        assert not test_file.exists()
-
-    def test_delete_files_exception_handling(self, mocker: MockerFixture) -> None:
-        """Test that exceptions are handled correctly during file deletion."""
-        # Arrange
-        directory = "/fake/directory"
-        mocker.patch("os.listdir", side_effect=Exception("List error"))
-        mock_logger_error = mocker.patch("builtins.print")
-
-        # Act
-        Utils.delete_files(directory)
-
-        # Assert
-        mock_logger_error.assert_called_once_with("Error deleting files: List error")
-
-    def test_failed_to_delete_exception_handling(self, mocker: MockerFixture) -> None:
-        """Test that an exception is handled correctly when file deletion fails."""
-        # Arrange
-        directory = "/fake/directory"
-        filenames_to_delete = ["file1.txt"]
-        mocker.patch("os.listdir", return_value=filenames_to_delete)
-        mocker.patch("os.path.isfile", return_value=True)
-        mocker.patch(
-            "os.path.getmtime", return_value=time.time() - 86400 * 31
-        )  # File older than 30 days
-        mock_remove = mocker.patch(
-            "os.remove", side_effect=Exception("Mocked exception")
-        )
-        mock_print = mocker.patch("builtins.print")
-
-        # Act
-        Utils.delete_files(directory, days=30, filenames_to_delete=filenames_to_delete)
-
-        # Assert
-        mock_remove.assert_called_once_with(os.path.join(directory, "file1.txt"))
-        mock_print.assert_called_once_with(
-            f"Failed to delete {os.path.join(directory, 'file1.txt')}: Mocked exception"
-        )
-
     def test_extract_first_name_from_full_name(self) -> None:
         """Test extracting first name from full name."""
         # Arrange
@@ -1131,3 +1029,102 @@ class TestUtils:
 
         # Assert
         assert result == ""
+
+    def test_make_serializable_primitives(self) -> None:
+        """Test make_serializable handles primitive types as-is."""
+        assert Utils.make_serializable(1) == 1
+        assert Utils.make_serializable(3.14) == 3.14
+        assert Utils.make_serializable("hi") == "hi"
+        assert Utils.make_serializable(True) is True
+        assert Utils.make_serializable(None) is None
+
+    def test_make_serializable_nested_dict_and_list(self) -> None:
+        """Test make_serializable handles nested dicts and lists."""
+        data = {"int": 1, "list": [1, 2, {"a": 3}], "dict": {"nested": "val"}}
+        result = Utils.make_serializable(data)
+        assert result == {"int": 1, "list": [1, 2, {"a": 3}], "dict": {"nested": "val"}}
+
+    def test_make_serializable_non_serializable(self) -> None:
+        """Test make_serializable converts non-serializable objects to strings."""
+        dt = types.SimpleNamespace(x=10)
+        myset = {1, 2, 3}
+        mytuple = (4, 5)
+
+        class MyClass:
+            def __str__(self) -> str:
+                return "MyClassInstance"
+
+        d = {
+            "obj": dt,
+            "set": myset,
+            "tuple": mytuple,
+            "custom": MyClass(),
+        }
+        result = Utils.make_serializable(d)
+        assert result["obj"].startswith("namespace") and "x=10" in result["obj"]
+        assert result["set"].startswith("{1") or result["set"].startswith(
+            "{2"
+        )  # As str
+        assert result["tuple"] == str(mytuple)
+        assert result["custom"] == "MyClassInstance"
+
+    def test_make_serializable_empty_collections(self) -> None:
+        """Test make_serializable returns empty collections as is or stringifies empty sets."""
+        assert Utils.make_serializable({}) == {}
+        assert Utils.make_serializable([]) == []
+        assert Utils.make_serializable(set()) == "set()"  # As str
+
+    def test_make_serializable_mixed(self) -> None:
+        """Test make_serializable with a mixed list including sets and objects."""
+        data = [{"num": 1}, (2, 3), {4, 5}, Dummy()]
+        result = Utils.make_serializable(data)
+        assert result[0] == {"num": 1}
+        assert result[1] == str((2, 3))
+        # Result[2] as str({'4, 5'}) - order is arbitrary
+        assert result[2] == "{4, 5}" or result[2] == "{5, 4}"
+        assert result[3] == "DummyInstance"
+
+    def test_yaml_dumps_basic(self) -> None:
+        """Test yaml_dumps correctly serializes a basic dict."""
+        d = {"a": 1, "b": "string", "c": True}
+        yml = Utils.yaml_dumps(d)
+        assert yml is not None
+        assert "a: 1" in yml
+        assert "b: string" in yml
+        assert "c: true" in yml
+
+    def test_yaml_dumps_nested(self) -> None:
+        """Test yaml_dumps handles nested structures and tuples."""
+        d = {"a": [1, 2, {"b": (1, 2)}]}
+        yml = Utils.yaml_dumps(d)
+        assert yml is not None
+        assert "a:" in yml
+        assert "- 1" in yml
+        assert "- 2" in yml
+        assert "b: (1, 2)" in yml
+
+    def test_yaml_dumps_empty_dict(self) -> None:
+        """Test yaml_dumps returns None for an empty dictionary."""
+        assert Utils.yaml_dumps({}) is None
+
+    def test_yaml_dumps_none(self) -> None:
+        """Test yaml_dumps returns None for None input."""
+        assert Utils.yaml_dumps(None) is None
+
+    def test_yaml_dumps_non_serializable(self) -> None:
+        """Test yaml_dumps serializes dicts with custom object values."""
+        d = {"foo": Dummy()}
+        yml = Utils.yaml_dumps(d)
+        assert yml is not None
+        assert "foo: DummyInstance" in yml
+
+    def test_yaml_dumps_serialization_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test yaml_dumps returns None if yaml.dump raises an exception."""
+        # Patch yaml.dump to simulate an exception
+        monkeypatch.setattr(
+            "yaml.dump", lambda *a, **kw: (_ for _ in ()).throw(Exception("fail"))
+        )
+        d = {"a": 1}
+        assert Utils.yaml_dumps(d) is None


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [x] 🐛 Bug Fix
- [x] 🚀 Feature Request
- [x] 🔄 Refactor
- [x] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
This PR revises and refines several core agent operations relating to descriptor exporting and descriptor file dumping, serialization utilities, and memory handling. It also includes a bugfix for time zone handling in interact walker and general code modernization, improving developer affordance and internal structure.

- Resolves architectural redundancy in descriptor export logic
- Replaces and deprecates legacy YAML/JSON dumping and agent export utilities
- Refactors agent memory and vector store argument conventions
- Adds robust, standards-compliant YAML serialization capabilities

---

## **Description**
### **Bug Fixes:**
- **Time zone in message flood comparator:**  
  Resolved an issue in the interact walker where datetime-aware comparison could fail due to missing UTC localization. Applied `utc.localize` to ensure all datetimes are timezone-aware and comparable.

### **Feature Request:**
- **Robust YAML serialization:**  
  Added `yaml_dumps` and helper serializer functions to correctly handle dumping complex, non-serializable dictionaries to YAML (including custom objects, sets, and tuples).
- **Snake case converter:**  
  Added a convenient `to_snake_case` utility for improved naming consistency across modules.

### **Refactor Request:**
- **Descriptor Export/Import Modernization:**  
  Split the `export_descriptor` operation into two distinct helpers: `dump_descriptor()` for file output and `get_descriptor()` for in-memory retrieval, improving clarity and separation of concerns.
- **Graph Node Architecture:**  
  Removed obsolete `graph_self` and `graph_children` properties from the graph node archetype.
- **Vector Store Action:**  
  Renamed arguments in `export_knodes` for clarity and better developer affordance.
- **Module Deprecations:**  
  Deprecated and removed `dump_yaml_file`, `dump_json_file`, and `delete_files`. Also deprecated and removed the `export_agent` walker/endpoint, now replaced with `export_descriptor` and `export_daf`.
- **Memory Module Improvements:**  
  Refactored memory handling for more consistent and robust import/export processes.

---

## **Changes Made**
### High-Level Summary:
1. Replaced `export_descriptor` with `dump_descriptor()` and `get_descriptor()` helpers.
2. Removed `graph_self` and `graph_children` from graph node archetype.
3. Added proper UTC-localization in interact walker datetime comparison.
4. Revised argument names for `export_knodes` in `vector_store_action`.
5. Deprecated and removed `dump_yaml_file`, `dump_json_file`, `delete_files`, and `export_agent` walker/endpoint.
6. Added new `yaml_dumps` function and serialization helpers for YAML compliance.
7. Added `to_snake_case` utility function.
8. Refactored memory module for improved agent memory import/export.

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [x] Tests have been added or updated for new functionality.
- [x] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [x] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
1. Test `dump_descriptor()` outputs correct files, and `get_descriptor()` returns accurate descriptors in memory.
2. Use `yaml_dumps` to serialize complex dicts, including sets/tuples/custom objects.
3. Check that interact walker message flood logic now properly compares UTC-aware datetimes, avoiding previous exceptions.
4. Import/export agent memory and verify correct persistence/recall operations in the memory module.
5. Try to call deprecated/removed endpoints (`export_agent`, dump helpers) and confirm their absence.
6. Exercise vector store actions and confirm argument clarity and correct operation.

---

## **Additional Context**
- These changes streamline the agent’s export/import ecosystem, align serialization logic with YAML standards, and enhance developer experience with more intuitive function signatures and cleaner module structure.
- Existing scripts relying on deprecated endpoints or file dump utilities may require minor updates.

---

## **Questions or Concerns**
- Any integration issues with legacy YAML/JSON dump pipelines should be reported for further migration assistance.
- Please verify that all external consumers of graph node archetypes are compatible with the removal of `graph_self` and `graph_children`.

---