### PR TITLE
Docker proxy update

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,6 +52,11 @@ fi
 if [ "$JIVAS_ENVIRONMENT" == "development" ] && [ "$JIVAS_FILEINTERFACE" == "local" ]; then
     echo "Starting file server..."
     jac jvfileserve $JIVAS_FILES_ROOT_PATH &
+elif [ "$JIVAS_ENVIRONMENT" == "production" ] && [ "$JIVAS_FILEINTERFACE" == "s3" ]; then
+    echo "Starting proxy server..."
+    jac jvproxyserve &
+else
+    echo "File server not started. JIVAS_ENVIRONMENT: $JIVAS_ENVIRONMENT, JIVAS_FILEINTERFACE: $JIVAS_FILEINTERFACE"
 fi
 
 # Rest of script remains unchanged

--- a/jivas/__init__.py
+++ b/jivas/__init__.py
@@ -4,4 +4,4 @@ jivas package initialization.
 JIVAS is an Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions.
 """
 
-__version__ = "2.0.0-alpha.44"
+__version__ = "2.0.0-alpha.45"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires=">=3.12.0",
     install_requires=[
         "jvcli>=2.0.26",
-        "jvserve>=2.0.11",
+        "jvserve>=2.0.12",
         "pytz>=2024.2",
         "types-pytz>=2024.2.0.20241003",
         "schedule>=1.2.2",


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request introduces a conditional branch in the `docker/entrypoint.sh` script to handle production environments with an S3 file interface and updates the minimum required version of the `jvserve` package in `setup.py`. These changes improve environment-specific behavior and compatibility with recent features.

## Description
### Environment-Specific Behavior Updates
- Added a new conditional branch in the `docker/entrypoint.sh` script:
  - If the environment is set to production and the file interface is S3, a proxy server is started.
  - If either condition is not met, a log message is generated to indicate that the file server was not started.

### Dependency Updates
- Updated `setup.py` to require version `2.0.12` or higher of the `jvserve` package to ensure compatibility with the latest updates.

## Changes Made
1. Introduced conditional logic in `docker/entrypoint.sh` for starting the proxy server in production with S3 file interface.
2. Updated the minimum required version of `jvserve` to `2.0.12` in `setup.py` to support recent updates.
